### PR TITLE
Add soft-delete flag to matches

### DIFF
--- a/src/components/modals.tsx
+++ b/src/components/modals.tsx
@@ -37,7 +37,11 @@ export function NewMatchModal({
   const navigate = useNavigate();
   const [loading, setLoading] = useState(false);
   const isMobile = useIsMobile();
-  const { data: matches = [] } = useLiveQuery(() => matchCollection);
+  const { data: allMatches = [] } = useLiveQuery(() => matchCollection);
+  const matches = useMemo(
+    () => allMatches.filter((m) => !m.deleted),
+    [allMatches],
+  );
   const scouters = useMemo(() => {
     return [...new Set(matches.map((match) => match.scouter))];
   }, [matches]);

--- a/src/routes/scouting/$matchId/review.tsx
+++ b/src/routes/scouting/$matchId/review.tsx
@@ -4,7 +4,7 @@ import { JsonView } from "@/components/JsonView";
 import { ConfirmDialog, useConfirmDialog } from "@/components/modals";
 import { Button } from "@/components/ui/button";
 import { Timeline, TimelineItem } from "@/components/ui/timeline";
-import { matchCollection, useMatch } from "@/data/db";
+import { softDeleteMatch, useMatch } from "@/data/db";
 import { phaseDetails, phaseOrder } from "@/data/match";
 
 export const Route = createFileRoute("/scouting/$matchId/review")({
@@ -32,7 +32,7 @@ function Page(): ReactNode {
       cancelLabel: "Cancel",
       confirmVariant: "destructive",
       onConfirm: () => {
-        matchCollection.delete(matchId);
+        softDeleteMatch(matchId);
         navigate({ to: "/scouting" });
       },
     });

--- a/src/routes/scouting/index.tsx
+++ b/src/routes/scouting/index.tsx
@@ -16,7 +16,7 @@ import {
   TableHeader,
   TableRow,
 } from "@/components/ui/table";
-import { downloadMatches, matchCollection } from "@/data/db";
+import { downloadMatches, matchCollection, softDeleteMatch } from "@/data/db";
 import { phaseDetails, phaseOrder } from "@/data/match";
 import { cn, shortDayName } from "@/util";
 
@@ -26,7 +26,8 @@ export const Route = createFileRoute("/scouting/")({
 
 function Page(): ReactNode {
   const navigate = Route.useNavigate();
-  const { data: matches = [] } = useLiveQuery(() => matchCollection);
+  const { data: allMatches = [] } = useLiveQuery(() => matchCollection);
+  const matches = allMatches.filter((m) => !m.deleted);
   const canFinish = !!matches.filter((m) => m.finished !== undefined).length;
 
   const [newModalOpened, setNewModalOpened] = useState(false);
@@ -69,7 +70,7 @@ function Page(): ReactNode {
         confirmLabel: "Delete Match",
         cancelLabel: "Cancel",
         confirmVariant: "destructive",
-        onConfirm: () => matchCollection.delete(matchId),
+        onConfirm: () => softDeleteMatch(matchId),
       });
     },
     [openConfirmDialog],


### PR DESCRIPTION
Delete actions on the scout overview and review pages now mark matches
as deleted instead of removing them from the database. Soft-deleted
matches are hidden from the UI (match list, autocomplete suggestions)
but remain in local storage until the user clicks "Finish Scouting",
at which point they are permanently removed alongside the exported
finished matches.

https://claude.ai/code/session_01VywVNDMEM9KunTczvnAzvC