### PR TITLE
Add missing DialogDescription to NewMatchModal

### DIFF
--- a/src/components/modals.tsx
+++ b/src/components/modals.tsx
@@ -192,6 +192,9 @@ export function NewMatchModal({
         <DrawerContent>
           <DrawerHeader>
             <DrawerTitle>New Match</DrawerTitle>
+            <DrawerDescription className="sr-only">
+              Create a new scouting match
+            </DrawerDescription>
           </DrawerHeader>
           <div className="px-4 pb-4">{formContent}</div>
         </DrawerContent>
@@ -204,6 +207,9 @@ export function NewMatchModal({
       <DialogContent className="sm:max-w-md">
         <DialogHeader>
           <DialogTitle>New Match</DialogTitle>
+          <DialogDescription className="sr-only">
+            Create a new scouting match
+          </DialogDescription>
         </DialogHeader>
         {formContent}
       </DialogContent>


### PR DESCRIPTION
Adds visually hidden descriptions to both the Dialog and Drawer variants of NewMatchModal to fix the accessibility warning: "Missing Description or aria-describedby for DialogContent"

https://claude.ai/code/session_01VywVNDMEM9KunTczvnAzvC